### PR TITLE
Update URL

### DIFF
--- a/lib/swish_qr.rb
+++ b/lib/swish_qr.rb
@@ -5,7 +5,7 @@
 class SwishQr
   require 'httparty'
 
-  SWISH_QR_API_ENDPOINT="https://www.swish.bankgirot.se/qrg-swish/api/v1/prefilled"
+  SWISH_QR_API_ENDPOINT="https://mpc.getswish.net/qrg-swish/api/v1/prefilled"
   @result = {}
   @data_hash = {}
   @image_format


### PR DESCRIPTION
The main URL for the Swish API is now mpc.getswish.net